### PR TITLE
Clean up redundant codes

### DIFF
--- a/lib/OutsideClickHandler.jsx
+++ b/lib/OutsideClickHandler.jsx
@@ -17,22 +17,19 @@ class OutsideClickHandler extends React.Component {
   constructor(props) {
     super(props);
     this.handleOutsideClick = this.handleOutsideClick.bind(this);
+    this.setChildNode = this.setChildNode.bind(this);
   }
 
   componentDidMount() {
-    if (document.addEventListener) {
-      document.addEventListener('click', this.handleOutsideClick, this.props.useCapture);
-    } else {
-      document.attachEvent('onclick', this.handleOutsideClick);
-    }
+    document.addEventListener('click', this.handleOutsideClick, this.props.useCapture);
   }
 
   componentWillUnmount() {
-    if (document.removeEventListener) {
-      document.removeEventListener('click', this.handleOutsideClick, this.props.useCapture);
-    } else {
-      document.detachEvent('onclick', this.handleOutsideClick);
-    }
+    document.removeEventListener('click', this.handleOutsideClick, this.props.useCapture);
+  }
+
+  setChildNode(ref) {
+    this.childNode = ref;
   }
 
   handleOutsideClick(e) {
@@ -44,7 +41,7 @@ class OutsideClickHandler extends React.Component {
 
   render() {
     return (
-      <div ref={(ref) => { this.childNode = ref; }}>
+      <div ref={this.setChildNode}>
         {this.props.children}
       </div>
     );


### PR DESCRIPTION
From `v0.14`, React not support IE < 9. So, I remove attachEvent related to support old internet explorer.